### PR TITLE
chore: downgrade jvm version to 11

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,12 +19,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
-
+    
     kotlinOptions {
-        jvmTarget = "21"
+        jvmTarget = "11"
     }
 
     lint {


### PR DESCRIPTION
**Proposed Changes:**

People running a lower jdk version than 21, get build errors, i would suggest not being needlessly ahead of the curve
Many projects are running version 11

Unless there is some reason you chose to do this

**Steps:**

- [ ] Reviewed
- [ ] Deployed to Production
- [ ] Add release information to https://adromance.atlassian.net/wiki/spaces/TJ/pages/2279833601/QA+for+SDK+version+update+-+Flutter
