### PR TITLE
Better compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,12 +19,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
-
+    
     kotlinOptions {
-        jvmTarget = "21"
+        jvmTarget = "11"
     }
 
     lint {


### PR DESCRIPTION
Can you please set both Java and Kotlin targets to 11  for maximum compatibility.
I am using an older flutter version which does not support 21.

Newer flutter versions should support 11 and most flutter packages target 11.

Thank you
