### PR TITLE
chore: replace Reviewed/Deployed ticks with Testing Steps in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,7 @@
 
 - Description
 
-**Steps:**
+**Testing Steps:**
 
-- [ ] Reviewed
-- [ ] Deployed to Production
+- [ ]
 - [ ] Add release information to https://adromance.atlassian.net/wiki/spaces/TJ/pages/2279833601/QA+for+SDK+version+update+-+Flutter


### PR DESCRIPTION
## Summary

- Remove unused **Reviewed** and **Deployed** (and variants: QA'd, Published, Branch removed) checkboxes from PR templates
- Replace the **Steps** section with **Testing Steps** — a blank checklist authors fill in per PR
- Wiki / release information links preserved where present

Closes TENJIN-28215.

## Testing Steps

- [ ] Open a new PR in this repo and confirm the template shows Testing Steps with no Reviewed/Deployed ticks