### PR TITLE
Fix Android compile SDK compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ group 'com.tenjin_sdk'
 version '1.3.2'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     namespace 'com.tenjin_sdk'
 
     sourceSets {


### PR DESCRIPTION
**JIRA**:

- N/A — external contribution; fixes #46

**Proposed Changes:**

- Raise the Android library `compileSdkVersion` from 33 to 34 so the plugin can consume the AndroidX versions resolved by Tenjin Android SDK 1.20.0.
- Preserve `minSdkVersion 21`; this does not change device compatibility or the consuming application's target SDK.

**Testing Steps:**

- [x] Run `flutter pub get` in the example application.
- [x] Run `:tenjin_plugin:assembleRelease` with Java 21; the release AAR assembles successfully.
- [ ] Add release information to https://adromance.atlassian.net/wiki/spaces/TJ/pages/2279833601/QA+for+SDK+version+update+-+Flutter
